### PR TITLE
Allowed later versions of react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "react-native-carrier-info",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "React Native module bridge to obtain information about the user’s home cellular service provider.",
   "main": "index.js",
   "peerDependencies": {
-    "react-native": "^0.4.2"
+    "react-native": ">=0.4.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This package is tied to `^0.4.2` of react. 0.8.0 is now out and releases happen regularly. So i've changed to `>= 0.4.2`
