### PR TITLE
Use external gradle dependencies if available, current ones if not

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,17 +1,20 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
     }
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
 }


### PR DESCRIPTION
This PR converts the module to the style most react-native modules are using now - first it looks for external versions, and only defaults to internal (updated now) versions if the external ones don't exist

Should fix #9 