### PR TITLE
feat: add cocoapods support for react-native 0.60 auto-linking

### DIFF
--- a/react-native-carrier-info.podspec
+++ b/react-native-carrier-info.podspec
@@ -1,0 +1,19 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['name']
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/react-native-webrtc/react-native-carrier-info.git", :tag => "v#{s.version}" }
+  s.source_files  = "ios/RNCarrierInfo/*.{h,m}"
+
+  s.dependency 'React'
+end


### PR DESCRIPTION
This appears to work for me in my app - note that it is different than the default recommended podspec template from the react-native 0.60 upgrade docs (they recommend react-native-webview) in that the iOS folder here has a demo project in it, so instead of doing a `**/*.{h,m}` I specified the actual sub-folder